### PR TITLE
Clarify `.toString()` Javadoc a bit

### DIFF
--- a/src/main/java/org/apache/bytes/Bytes.java
+++ b/src/main/java/org/apache/bytes/Bytes.java
@@ -129,7 +129,7 @@ public final class Bytes extends AbstractByteSequence implements Comparable<Byte
   }
 
   /**
-   * Creates UTF-8 String using Bytes data
+   * Provides a String representation, decoding the bytes as UTF-8
    */
   @Override
   public String toString() {


### PR DESCRIPTION
(it does not create an «UTF-8 String», as all Strings in Java are UTF-16)